### PR TITLE
Colorize the Record/Stop button

### DIFF
--- a/pulsecaster/ui.py
+++ b/pulsecaster/ui.py
@@ -145,6 +145,7 @@ class PulseCasterUI(Gtk.Application):
         self.close.connect('clicked', self.on_close)
         self.record = self.builder.get_object('record_button')
         self.record_id = self.record.connect('clicked', self.on_record)
+        self.record.get_style_context().add_class("suggested-action")
         self.record.set_sensitive(True)
         self.main_logo = self.builder.get_object('logo')
         self.main_logo.set_from_icon_name('pulsecaster', Gtk.IconSize.DIALOG)
@@ -334,6 +335,8 @@ class PulseCasterUI(Gtk.Application):
 
         # FIXME: Dim elements other than the 'record' widget
         self.record.set_label(Gtk.STOCK_MEDIA_STOP)
+        self.record.get_style_context().remove_class("suggested-action")
+        self.record.get_style_context().add_class("destructive-action")
         self.record.disconnect(self.record_id)
         self.stop_id = self.record.connect('clicked', self.on_stop)
         self.record.show()
@@ -348,6 +351,8 @@ class PulseCasterUI(Gtk.Application):
         self.combiner.set_state(Gst.State.NULL)
         self.showFileChooser()
         self.record.set_label(Gtk.STOCK_MEDIA_RECORD)
+        self.record.get_style_context().remove_class("destructive-action")
+        self.record.get_style_context().add_class("suggested-action")
         self.record.disconnect(self.stop_id)
         self.record_id = self.record.connect('clicked', self.on_record)
         self.user_vox.cbox.set_sensitive(True)

--- a/pulsecaster/ui.py
+++ b/pulsecaster/ui.py
@@ -409,6 +409,8 @@ class PulseCasterUI(Gtk.Application):
                                                            Gtk.STOCK_OK,
                                                            Gtk.ResponseType.OK))
         self.file_chooser.set_local_only(True)
+        self.file_chooser.set_transient_for(self.main)
+        self.file_chooser.set_modal(True)
         response = self.file_chooser.run()
         if response == Gtk.ResponseType.OK:
             self.updateFileSinkPath()
@@ -430,6 +432,9 @@ class PulseCasterUI(Gtk.Application):
                                                  erase_message,
                                                  Gtk.ResponseType.YES),
                                         message_format=confirm_message)
+
+            confirm.set_transient_for(self.file_chooser)
+            confirm.set_modal(True)
             response = confirm.run()
             confirm.destroy()
             if response == Gtk.ResponseType.YES:


### PR DESCRIPTION
Some trivial changes to make the Record/Stop button colorful. It now looks like this:

![pulsecaster blue record button](https://user-images.githubusercontent.com/479401/154609327-f36ab79f-073b-40f5-acd1-b14970394a17.png)

![pulsecaster red stop button](https://user-images.githubusercontent.com/479401/154609352-c6fef60b-4b0c-4ec2-a0b8-cb5302fe88f0.png)

Also make dialogs modal and parented for great justice.

I ran the app by executing `python3 ui.py` in the pulsecaster GUI and it didn't seem like I broke anything, but please give it a shot.