### PR TITLE
ui: load also from local installation

### DIFF
--- a/pulsecaster/ui.py
+++ b/pulsecaster/ui.py
@@ -72,12 +72,22 @@ class PulseCasterUI(Gtk.Application):
                                                         'pulsecaster.ui'))
             except:
                 try:
-                    self.builder.add_from_file(os.path.join
-                                               (os.path.dirname(sys.argv[0]),
-                                                'data', 'pulsecaster.ui'))
-                except Exception as e:
-                    print(e)
-                    raise SystemExit(_("Cannot load resources"))
+                    self.builder.add_from_file(
+                        os.path.normpath(
+                            os.path.join(os.path.dirname(__file__),
+                                         '..',
+                                         'usr',
+                                         'share',
+                                         'pulsecaster',
+                                         'pulsecaster.ui')))
+                except:
+                    try:
+                        self.builder.add_from_file(os.path.join
+                                                   (os.path.dirname(sys.argv[0]),
+                                                    'data', 'pulsecaster.ui'))
+                    except Exception as e:
+                        print(e)
+                        raise SystemExit(_("Cannot load resources"))
 
         self.tempgsettings = Gtk.Settings.get_default()
         self.tempgsettings.set_property('gtk-application-prefer-dark-theme',
@@ -88,6 +98,16 @@ class PulseCasterUI(Gtk.Application):
                                                        'data',
                                                        'icons',
                                                        'scalable'))
+        self.icontheme.append_search_path(
+            os.path.normpath(
+                os.path.join(os.path.dirname(__file__),
+                             '..',
+                             'usr',
+                             'share',
+                             'icons',
+                             'hicolor',
+                             'scalable',
+                             'apps')))
         self.icontheme.append_search_path(os.path.join
                                           (os.path.dirname(sys.argv[0]),
                                            'data', 'icons', 'scalable'))


### PR DESCRIPTION
Installing locally with pip, pulsecaster fails with:

  "
    g-file-error-quark: Failed to open file “$HOME/.local/bin/data/pulsecaster.ui”: No such file or directory (4)
    Cannot load resources
  "

Or

  "
    Traceback (most recent call last):
      File "$HOME/.local/lib/python3.9/site-packages/pulsecaster/ui.py", line 114, in on_activate
        self.logo = self.icontheme.load_icon('pulsecaster', -1,
    gi.repository.GLib.Error: gtk-icon-theme-error-quark: Icon 'pulsecaster' not present in theme Adwaita (0)
  "